### PR TITLE
Abort a request if the user is not found

### DIFF
--- a/pylodon/utilities.py
+++ b/pylodon/utilities.py
@@ -120,7 +120,7 @@ def find_user(handle):
     """
     u = mongo.db.users.find_one({'username': handle}, {'_id': False})
     if not u:
-        return None
+        abort(404)
     return u
 
 
@@ -131,5 +131,5 @@ def find_post(handle, post_id):
     id = user_api_uri+'/'+post_id
     p = mongo.db.posts.find_one({'object.id': id}, {'_id': False})
     if not p:
-        return None
+        abort(404)
     return p


### PR DESCRIPTION
This is probably totally the wrong thing to do. But it seems better than throwing 500's?